### PR TITLE
chore: disable CI jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
   check:
     name: Check (msrv)
     runs-on: ubuntu-latest
-    if: github.repository == 'helix-editor/helix' || github.event_name != 'schedule'
+    if: false # job not enabled on this fork
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
   test:
     name: Test Suite
     runs-on: ${{ matrix.os }}
-    if: github.repository == 'helix-editor/helix' || github.event_name != 'schedule'
+    if: false # job not enabled on this fork
     timeout-minutes: 30
     env:
       RUST_BACKTRACE: 1
@@ -82,7 +82,7 @@ jobs:
   lints:
     name: Lints
     runs-on: ubuntu-latest
-    if: github.repository == 'helix-editor/helix' || github.event_name != 'schedule'
+    if: false # job not enabled on this fork
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -118,7 +118,7 @@ jobs:
   docs:
     name: Docs
     runs-on: ubuntu-latest
-    if: github.repository == 'helix-editor/helix' || github.event_name != 'schedule'
+    if: false # job not enabled on this fork
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   publish:
+    if: false # job not enabled on this fork
     name: Publish Flake
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   deploy:
+    if: false # job not enabled on this fork
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,8 @@ name: Release
 on:
   push:
     tags:
-    - '*' # enable release on any tag on this fork
+    - '[0-9]+.[0-9]+-*'
+    - '[0-9]+.[0-9]+.[0-9]+-*'
     branches:
     - 'patch/ci-release-*'
   pull_request:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,7 @@ name: Release
 on:
   push:
     tags:
-    - '[0-9]+.[0-9]+'
-    - '[0-9]+.[0-9]+.[0-9]+'
+    - '*' # enable release on any tag on this fork
     branches:
     - 'patch/ci-release-*'
   pull_request:
@@ -15,7 +14,7 @@ env:
   # a release, allowing for manual inspection of the output. This mode is
   # activated if the CI run was triggered by events other than pushed tags, or
   # if the repository is a fork.
-  preview: ${{ !startsWith(github.ref, 'refs/tags/') || github.repository != 'helix-editor/helix' }}
+  preview: false # disabled for this fork
 
 jobs:
   fetch-grammars:
@@ -144,7 +143,7 @@ jobs:
           echo "target flag is: ${{ env.TARGET_FLAGS }}"
 
       - name: Run cargo test
-        if: "!matrix.skip_tests"
+        if: false # tests disabled on this fork
         run: ${{ env.CARGO }} test --release --locked --target ${{ matrix.target }} --workspace
 
       - name: Build release binary


### PR DESCRIPTION
fixes #40 

this has allowed a release with artifacts on my fork see https://github.com/parisni/vim.hx/releases/tag/0.0.1

however i am wondering if you also wan't to run the tests for each platforms ? the window's one is quite long. on the other hand, the less we touch the ci files the easier will be the rebase on upstream.

let me know