### PR TITLE
Fix: allow non-yank operators to work like multi-cursor in Visual Block

### DIFF
--- a/helix-term/src/commands/vim_patch.rs
+++ b/helix-term/src/commands/vim_patch.rs
@@ -1273,7 +1273,7 @@ impl VimOpCtx {
     pub fn operator_impl(cx: &mut Context, op: VimOp, register: Option<char>) {
         let opcx = Self::with_custom_register(cx, op, register);
         if cx.editor.mode == Mode::Select {
-            if VIM_STATE.is_visual_block() {
+            if VIM_STATE.is_visual_block() && op == VimOp::Yank {
                 // Copy/Paste from yank_joined
                 let separator = doc!(cx.editor).line_ending.as_str();
                 yank_joined_impl(

--- a/helix-term/src/commands/vim_patch.rs
+++ b/helix-term/src/commands/vim_patch.rs
@@ -1279,8 +1279,7 @@ impl VimOpCtx {
                 yank_joined_impl(
                     cx.editor,
                     separator,
-                    cx.register
-                        .unwrap_or(cx.editor.config().default_yank_register),
+                    register.unwrap_or(cx.editor.config().default_yank_register),
                 );
                 vim_exit_select_mode(cx);
                 return;


### PR DESCRIPTION
Close #56